### PR TITLE
NO-STORY: Add backlog index README scaffold

### DIFF
--- a/docs/cmsg/docs/backlog-readme.md
+++ b/docs/cmsg/docs/backlog-readme.md
@@ -1,0 +1,20 @@
+NO-STORY: Add backlog index README scaffold
+
+## Description
+- Created `docs/shared/user-stories/README.md` as the central backlog index.
+- Added table with Sprint 0 user stories (US-00001 to US-00005).
+- Included status column to track progress (currently marked as In Progress).
+- Added status legend for clarity.
+
+## Rationale
+Backlog index provides a single source of truth for all user stories.  
+This improves transparency, avoids duplication across sprint docs, and ensures traceability.
+
+## Scope
+- Added new file: `docs/shared/user-stories/README.md`.
+- Populated table with Sprint 0 planned stories.
+- Linked to individual story files for future reference.
+
+## Impact
+- Backlog index will be updated at the end of each sprint to reflect completed or re-prioritized stories.
+- All future user stories must be added here when created.

--- a/docs/retro_notes/sprint-0/docs/backlog-readme.md
+++ b/docs/retro_notes/sprint-0/docs/backlog-readme.md
@@ -1,0 +1,15 @@
+NO-STORY: Add backlog index README scaffold
+
+## ✅ What Went Well
+- Successfully added a central backlog index (`docs/shared/user-stories/README.md`).
+- Table structure is clear and easy to update with priorities and statuses.
+- Having the status legend will help keep consistency in later updates.
+
+## ⚠️ What Could Be Improved
+- This artifact was discovered mid-sprint rather than planned, which shows gaps in initial story definition.
+- Could have included backlog index creation as part of US-00002 (documentation scaffold).
+
+## 🔁 Action Items
+- Always confirm that **all key Agile artifacts** (backlog, story index, sprint docs) are included in the scope of planning stories.
+- Build a quick checklist for Sprint 1 planning to ensure new artifact needs are identified early.
+- Standardize on 5-digit IDs and update any references in backlog index once the ID renaming is complete.

--- a/docs/shared/user-stories/README.md
+++ b/docs/shared/user-stories/README.md
@@ -1,0 +1,31 @@
+# 📋 Backlog Index – Practica App
+
+This file tracks all user stories for the Practica App.  
+It serves as the **single source of truth** for backlog items, their priority, and current status.  
+
+Stories planned in a sprint are linked here; sprint docs do not duplicate the details.  
+
+---
+
+## 📑 User Stories
+
+| ID | Title | Priority | Status |
+|----|-------|----------|--------|
+| [US-00001](US-00001.md) | Expo + React Native Web App Scaffold | High | 🔄 In Progress |
+| [US-00002](US-00002.md) | Documentation Folder Scaffold | High | 🔄 In Progress |
+| [US-00003](US-00003.md) | Define Product Vision & Personas | High | 🔄 In Progress |
+| [US-00004](US-00004.md) | CI Setup for Testing | Medium | 🔄 In Progress |
+| [US-00005](US-00005.md) | Deploy Build to Netlify | Medium | 🔄 In Progress |
+
+---
+
+## 📌 Status Legend
+
+- ✅ Completed  
+- 🔄 In Progress  
+- 📋 Backlog (not yet planned)  
+- ❌ Closed (dropped or replaced)  
+- ⏸ Split → new story ID(s)  
+
+---
+


### PR DESCRIPTION
## Description
- Created `docs/shared/user-stories/README.md` as the central backlog index.
- Added table with all existing user stories (US-00001 to US-00005) to README.md.
- Included status column to track progress (currently marked as In Progress).
- Added status legend for clarity.

## Rationale
Backlog index provides a single source of truth for all user stories. This improves transparency, avoids duplication across sprint docs, and ensures traceability.

## Scope
- Added new file: `docs/shared/user-stories/README.md`.
- Populated table with Sprint 0 planned stories.
- Linked to individual story files for future reference.

## Impact
- Backlog index will be updated at the end of each sprint to reflect completed or re-prioritized stories.
- All future user stories must be added here when created.