### PR TITLE
CHORE: Standardize user story IDs to 5-digit format

### DIFF
--- a/docs/cmsg/chore/story-id-five-digits.md
+++ b/docs/cmsg/chore/story-id-five-digits.md
@@ -1,0 +1,24 @@
+CHORE-000: Standardize user story IDs to 5-digit format
+
+## Description
+- Renamed story files from 4-digit IDs to 5-digit IDs (e.g., US-0001 → US-00001).
+- Updated references in backlog index, story index, Sprint 0 docs, and methodology examples.
+
+## Rationale
+Consistent 5-digit IDs improve scalability and traceability across docs, branches, and PRs.
+
+Additionally, this work clarified how non-story items (chores, docs, fixes) should be handled:
+- No numeric IDs will be assigned to non-story work.
+- Such branches will use descriptive prefixes (`chore/`, `docs/`, `fix/`).
+- Commit messages will follow Conventional Commits style (e.g., `chore: …`).
+- Optional tracking via GitHub Issues or `docs/shared/ops-log.md`.
+
+## Scope
+- File renames in `docs/shared/user-stories/`.
+- Link updates in:
+  - `docs/shared/user-stories/README.md`
+  - `docs/sprints/sprint-0/sprint-overview.md`
+  - `docs/shared/agile-methodology.md`
+
+## Impact
+- All future branches/stories must use 5-digit IDs (e.g., `feature/US-00006-title`).

--- a/docs/retro_notes/chore/story-id-five-digits.md
+++ b/docs/retro_notes/chore/story-id-five-digits.md
@@ -1,0 +1,17 @@
+CHORE: Standardize user story IDs to 5-digit format
+
+## ✅ What Went Well
+- Consolidated on a single, scalable ID format (5 digits) without breaking links.
+- Explicit checklist prevented missed references.
+- Clarified how to handle non-story work (chores, docs, fixes) as part of this standardization.
+- Decided to drop numeric CHORE IDs and rely on descriptive branch prefixes and Conventional Commit messages.
+
+## ⚠️ What Could Be Improved
+- ID format decision surfaced mid-sprint; should be defined earlier in methodology.
+- Large find/replace operations can be error-prone—prefer explicit targets and spot checks.
+
+## 🔁 Action Items
+- Document 5-digit ID rule in `agile-methodology.md` (done).
+- Add an “ID format” item to the project bootstrap checklist for future repos.
+- Consider a small script/check to validate story ID patterns in CI later.
+- Incorporate non-story work guidelines into `agile-methodology.md` (as part of US-00006).

--- a/docs/shared/Templates/completed stories.md
+++ b/docs/shared/Templates/completed stories.md
@@ -1,16 +1,16 @@
-# 📝 Completed Story – [US-XXXX Title]
+# 📝 Completed Story – [US-XXXXX Title]
 
 ## 📖 Story Reference
-- **Story ID:** US-XXXX  
+- **Story ID:** US-XXXXX  
 - **Planned In:** Sprint XX  
-- **Original Story File:** [US-XXXX](../../shared/user-stories/US-XXXX.md)  
-- **Result Link (Story Index):** [Back to Story Index](../../shared/story-index.md#us-xxxx)
+- **Original Story File:** [US-XXXXX](../../shared/user-stories/US-XXXXX.md)  
+- **Result Link (Story Index):** [Back to Story Index](../../shared/story-index.md#us-xxxxx)
 
 ---
 
 ## 🎯 Story Goal
 As a [role], I want [goal], so that [reason].  
-*(Original: [US-XXXX](../../shared/user-stories/US-XXXX.md))*
+*(Original: [US-XXXXX](../../shared/user-stories/US-XXXXX.md))*
 
 ---
 
@@ -18,7 +18,7 @@ As a [role], I want [goal], so that [reason].
 - [ ] Criterion 1  
 - [ ] Criterion 2  
 - [ ] Criterion 3  
-*(Original: [US-XXXX](../../shared/user-stories/US-XXXX.md))*
+*(Original: [US-XXXXX](../../shared/user-stories/US-XXXXX.md))*
 
 ---
 
@@ -29,7 +29,7 @@ As a [role], I want [goal], so that [reason].
 - **Pull Requests (if applicable):**  
   - [PR #22 – Flashcard Feature](https://github.com/your/repo/pull/22)  
 - **Squash Commit in `main`:**  
-  - [`US-XXXX: Feature summary`](https://github.com/your/repo/commit/abc123)
+  - [`US-XXXXX: Feature summary`](https://github.com/your/repo/commit/abc123)
 
 ---
 

--- a/docs/shared/Templates/test-cases.md
+++ b/docs/shared/Templates/test-cases.md
@@ -1,10 +1,10 @@
 
 ## 🧪 Templates
 
-### Test Case (`TC-FC-0001.md`)
+### Test Case (`TC-FC-00001.md`)
 ```markdown
 ---
-id: TC-FC-0001
+id: TC-FC-00001
 title: View first card (front)
 feature: flashcards
 priority: P1

--- a/docs/shared/agile-methodology.md
+++ b/docs/shared/agile-methodology.md
@@ -32,7 +32,7 @@ I follow an Agile-inspired methodology focused on:
 ### 🔹 Backlog
 
 All user stories are stored in the **backlog folder**: `docs/shared/user-stories/`.  
-Each story has its own file (`US-0001.md`, `US-0002.md`, etc.) containing its ID, description, persona, and acceptance criteria.  
+Each story has its own file (`US-00001.md`, `US-00002.md`, etc.) containing its ID, description, persona, and acceptance criteria.  
 
 A `README.md` in the same folder acts as the **backlog index**, providing an overview of stories with their **current priority and status**. Sprint files do not duplicate story details — they only link to these story files.  
 
@@ -47,10 +47,10 @@ Backlog stories may evolve by:
 
 | ID      | Title          | Priority | Status       |
 |---------|----------------|----------|--------------|
-| [US-0001](US-0001.md) | Email Sign-up   | High     | ✅ Completed |
-| [US-0002](US-0002.md) | Login           | High     | 🔄 In Progress |
-| [US-0003](US-0003.md) | Profile Page    | Medium   | 📋 Backlog |
-| [US-0004](US-0004.md) | Password Reset  | Low      | ❌ Closed |
+| [US-00001](US-00001.md) | Email Sign-up   | High     | ✅ Completed |
+| [US-00002](US-00002.md) | Login           | High     | 🔄 In Progress |
+| [US-00003](US-00003.md) | Profile Page    | Medium   | 📋 Backlog |
+| [US-00004](US-00004.md) | Password Reset  | Low      | ❌ Closed |
 
 ---
 
@@ -71,10 +71,10 @@ This file acts as the **central map** connecting backlog entries with sprint out
 
 | ID      | Title          | Sprint  | Outcome                  | Result Link |
 |---------|----------------|---------|--------------------------|-------------|
-| US-0001 | Email Sign-up  | Sprint 1 | ✅ Completed             | [Results](../sprints/sprint-01/completed-stories.md#us-0001) |
-| US-0002 | Login          | Sprint 2 | 🔄 In Progress           | - |
-| US-0003 | Profile Page   | Sprint 2 | ⏸ Split → US-0010, US-0011 | - |
-| US-0004 | Password Reset | Sprint 2 | ❌ Closed (not needed)   | - |
+| US-00001 | Email Sign-up  | Sprint 1 | ✅ Completed             | [Results](../sprints/sprint-01/completed-stories.md#us-00001) |
+| US-00002 | Login          | Sprint 2 | 🔄 In Progress           | - |
+| US-00003 | Profile Page   | Sprint 2 | ⏸ Split → US-00010, US-00011 | - |
+| US-00004 | Password Reset | Sprint 2 | ❌ Closed (not needed)   | - |
 
 ### 🔹 Shared Documents
 
@@ -137,15 +137,15 @@ Optional: for public releases, create versioned tags (e.g., `v0.1.0`).
 
 ```bash
 # Start a feature branch
-git checkout -b feature/US-0002-login
+git checkout -b feature/US-00002-login
 
 # Work and commit with full history
-git commit -m "feat(auth): add login form [US-0002]"
+git commit -m "feat(auth): add login form [US-00002]"
 
 # Squash into main when story is complete
 git checkout main
-git merge --squash feature/US-0002-login
-git commit -m "US-0002: Login with email"
+git merge --squash feature/US-00002-login
+git commit -m "US-00002: Login with email"
 
 # Tag sprint milestone at sprint end
 git tag -a sprint-01-complete -m "End of Sprint 01"
@@ -164,7 +164,7 @@ All commits follow this format:
 
 `<type>(<scope>): <summary> [Story ID]`
 
-- Example: `feat(auth): add login validation [US-0004]`
+- Example: `feat(auth): add login validation [US-00004]`
 - Types: `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`
 - Scope is optional but encouraged for clarity
 - Bracketed Story ID links commit to sprint planning
@@ -172,7 +172,7 @@ All commits follow this format:
 Documentation updates should use the `docs()` type and include the path to the updated file.
 
 Example:
-docs: updated shared/user-personas.md to include new target learner group [US-0003]
+docs: updated shared/user-personas.md to include new target learner group [US-00003]
 
 ### 🔸 Non-Story Commits
 

--- a/docs/shared/ci-cd-overview
+++ b/docs/shared/ci-cd-overview
@@ -48,5 +48,5 @@
 
 ## 📝 Where this shows up in docs
 - `sprints/sprint-XX/sprint-overview.md`: links to PR previews / prod URL.
-- `sprints/sprint-XX/completed-stories/US-XXXX.md`: acceptance evidence includes preview/prod link when available.
+- `sprints/sprint-XX/completed-stories/US-XXXXX.md`: acceptance evidence includes preview/prod link when available.
 - `sprints/sprint-XX/retrospective.md`: note CI/CD wins/issues.

--- a/docs/shared/testing-docs.md
+++ b/docs/shared/testing-docs.md
@@ -11,26 +11,26 @@ docs/
 ├─ shared/
 │  ├─ user-stories/                  # backlog (planned stories)
 │  │   ├─ README.md                  # backlog index
-│  │   ├─ US-0001.md
-│  │   └─ US-0002.md
+│  │   ├─ US-00001.md
+│  │   └─ US-00002.md
 │  └─ test-cases/                    # reusable, single-file test cases
 │      ├─ README.md                  # index of all cases
-│      ├─ TC-FC-0001.md              # Flashcard – View first card
-│      ├─ TC-FC-0002.md              # Flashcard – Flip card
-│      └─ TC-AU-0001.md              # Audio – Play pronunciation
+│      ├─ TC-FC-00001.md              # Flashcard – View first card
+│      ├─ TC-FC-00002.md              # Flashcard – Flip card
+│      └─ TC-AU-00001.md              # Audio – Play pronunciation
 └─ sprints/
    └─ sprint-01/
       ├─ sprint-overview.md          # goal, planned stories, related docs
       ├─ sprint-scope-testing.md     # which test cases executed this sprint
       ├─ completed-stories/          # one file per story outcome
-      │   ├─ US-0001.md              # references test cases + session logs
-      │   └─ US-0002.md
+      │   ├─ US-00001.md              # references test cases + session logs
+      │   └─ US-00002.md
       └─ tests/                      # actual test execution (per sprint)
          ├─ test-session-2025-09-24.md   # log of cases run + results
          └─ screenshots/                 # proof attached to session/story
-            ├─ tc-fc-0001_iphone.png
-            ├─ tc-fc-0002_android.png
-            └─ tc-au-0001_chrome.png
+            ├─ tc-fc-00001_iphone.png
+            ├─ tc-fc-00002_android.png
+            └─ tc-au-00001_chrome.png
 
 ---
 
@@ -38,17 +38,17 @@ docs/
 
 | File | Purpose |
 |------|---------|
-| `shared/test-cases/TC-XXXX.md` | Single test case (steps, expected result, tags) |
+| `shared/test-cases/TC-XXXXX.md` | Single test case (steps, expected result, tags) |
 | `shared/test-cases/README.md` | Index of all cases with links, grouped by feature |
 | `sprint-XX/sprint-scope-testing.md` | Which test cases were executed in this sprint |
-| `sprint-XX/completed-stories/US-XXXX.md` | Story results: which cases verified it, evidence, pass/fail |
+| `sprint-XX/completed-stories/US-XXXXX.md` | Story results: which cases verified it, evidence, pass/fail |
 | `sprint-XX/tests/test-session-YYYY-MM-DD.md` | Execution log: results of running cases (story + non-story) |
 
 ---
 
 ## 🔖 Naming Conventions
 - **Test cases:** `TC-<feature>-<number>.md`  
-  Example: `TC-FC-0001.md` (Flashcards – Case 1)  
+  Example: `TC-FC-00001.md` (Flashcards – Case 1)  
 - **Session logs:** `test-session-YYYY-MM-DD.md`  
   Example: `test-session-2025-09-24.md`  
 
@@ -56,10 +56,10 @@ docs/
 
 ## 🧪 Templates
 
-### Test Case (`TC-FC-0001.md`)
+### Test Case (`TC-FC-00001.md`)
 ```markdown
 ---
-id: TC-FC-0001
+id: TC-FC-00001
 title: View first card (front)
 feature: flashcards
 priority: P1

--- a/docs/shared/user-stories/US-00001.md
+++ b/docs/shared/user-stories/US-00001.md
@@ -1,4 +1,4 @@
-# US-0001 – Expo + React Native Web App Scaffold
+# US-00001 – Expo + React Native Web App Scaffold
 
 **Persona:** Developer  
 

--- a/docs/shared/user-stories/US-00002.md
+++ b/docs/shared/user-stories/US-00002.md
@@ -1,4 +1,4 @@
-# US-0002 – Documentation Folder Scaffold
+# US-00002 – Documentation Folder Scaffold
 
 **Persona:** Project Manager  
 

--- a/docs/shared/user-stories/US-00003.md
+++ b/docs/shared/user-stories/US-00003.md
@@ -1,4 +1,4 @@
-# US-0003 – Initial Product Vision & Personas
+# US-00003 – Initial Product Vision & Personas
 
 **Persona:** Business Analyst  
 

--- a/docs/shared/user-stories/US-00004.md
+++ b/docs/shared/user-stories/US-00004.md
@@ -1,4 +1,4 @@
-# US-0004 – Basic CI for Testing
+# US-00004 – Basic CI for Testing
 
 **Persona:** Developer  
 

--- a/docs/shared/user-stories/US-00005.md
+++ b/docs/shared/user-stories/US-00005.md
@@ -1,4 +1,4 @@
-# US-0005 – Deploy to Netlify
+# US-00005 – Deploy to Netlify
 
 **Persona:** Developer  
 

--- a/docs/sprints/sprint-0/sprint-overview.md
+++ b/docs/sprints/sprint-0/sprint-overview.md
@@ -13,11 +13,11 @@ End: [2025-07-20]
 
 | ID | User Story |
 |----|------------|
-| US-0001 | As a developer, I want to create a working Expo + React Native Web app so that I can test across browser and mobile easily. |
-| US-0002 | As a project manager, I want to scaffold shared and sprint documentation folders so that work can be tracked across iterations. |
-| US-0003 | As a business analyst, I want to define the initial product vision and personas so that the project starts user-centered. |
-| US-0004 | As a developer, I want to set up basic CI for testing so that errors are caught automatically on every push. |
-| US-0005 | As a developer, I want to deploy a working build to Netlify so early testers can access it without installation. |
+| [US-00001](../../shared/user-stories/US-00001.md) | As a developer, I want to create a working Expo + React Native Web app so that I can test across browser and mobile easily. |
+| [US-00002](../../shared/user-stories/US-00002.md) | As a project manager, I want to scaffold shared and sprint documentation folders so that work can be tracked across iterations. |
+| [US-00003](../../shared/user-stories/US-00003.md) | As a business analyst, I want to define the initial product vision and personas so that the project starts user-centered. |
+| [US-00004](../../shared/user-stories/US-00004.md) | As a developer, I want to set up basic CI for testing so that errors are caught automatically on every push. |
+| [US-00005](../../shared/user-stories/US-00005.md) | As a developer, I want to deploy a working build to Netlify so early testers can access it without installation. |
 
 ---
 


### PR DESCRIPTION
## Description
- Renamed story files from 4-digit IDs to 5-digit IDs (e.g., US-0001 → US-00001).
- Updated references in backlog index, story index, Sprint 0 docs, and methodology examples.

## Rationale
Consistent 5-digit IDs improve scalability and traceability across docs, branches, and PRs.

Additionally, this work clarified how non-story items (chores, docs, fixes) should be handled:
- No numeric IDs will be assigned to non-story work.
- Such branches will use descriptive prefixes (`chore/`, `docs/`, `fix/`).
- Commit messages will follow Conventional Commits style (e.g., `chore: …`).
- Optional tracking via GitHub Issues or `docs/shared/ops-log.md`.

## Scope
- File renames in `docs/shared/user-stories/`.
- Link updates in:
  - `docs/shared/user-stories/README.md`
  - `docs/sprints/sprint-0/sprint-overview.md`
  - `docs/shared/agile-methodology.md`

## Impact
- All future branches/stories must use 5-digit IDs (e.g., `feature/US-00006-title`).